### PR TITLE
Add multidex support for pre-Lollipop device, add dex count plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,7 @@ buildscript {
 apply plugin: "jacoco"
 apply plugin: 'com.android.application'
 apply plugin: 'com.jakewharton.hugo'
+apply plugin: 'com.getkeepsafe.dexcount'
 
 repositories {
   maven { url 'https://maven.fabric.io/public' }
@@ -79,6 +80,8 @@ dependencies {
   repositories {
     mavenCentral()
   }
+
+  compile 'com.android.support:multidex:1.0.1'
   compile 'com.android.support:support-v4:23.1.1'
   compile 'com.android.support:appcompat-v7:23.1.1'
   compile 'com.android.support:recyclerview-v7:23.1.1'

--- a/app/src/main/java/com/soi/rapidandroidapp/BaseApplication.java
+++ b/app/src/main/java/com/soi/rapidandroidapp/BaseApplication.java
@@ -21,10 +21,13 @@ import javax.inject.Inject;
 
 import io.fabric.sdk.android.Fabric;
 
+import android.support.multidex.MultiDex;
+import android.support.multidex.MultiDexApplication;
+
 /**
  * Created by spirosoikonomakis on 3/9/14.
  */
-public class BaseApplication extends Application {
+public class BaseApplication extends MultiDexApplication {
 
     @Inject
     EnvironmentManager environmentManager;
@@ -113,5 +116,15 @@ public class BaseApplication extends Application {
         APP_TRACKER, // Tracker used only in this app.
         GLOBAL_TRACKER, // Tracker used by all the apps from a company. eg: roll-up tracking.
         ECOMMERCE_TRACKER, // Tracker used by all ecommerce transactions from a company.
+    }
+
+    /**
+     * Support for pre-Lollipop multidex
+     *
+     * @param context
+     */
+    protected void attachBaseContext(Context context) {
+       super.attachBaseContext(context);
+       MultiDex.install(this);
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:1.3.0'
         classpath 'com.jakewharton.hugo:hugo-plugin:1.2.1'
+        classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
This pr will fix dagger error. For pre-Lollipop device we need to add 
  compile 'com.android.support:multidex:1.0.1' and extend our BaseApplication with MultiDexApplication instead Application.

I also add dex-count plugin to inform us how many methods in the project.